### PR TITLE
Fix indentation for an URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 ![:octocat:](https://assets-cdn.github.com/images/icons/emoji/octocat.png ":octocat:")The Project has been started by [Juuso (jeukku)](https://github.com/jeukku) in order to form a template example   
 that could be used across The Zeitgeist Movement Chapters' websites hosted on any GitHub Repository.
 
-Documentation how to use this template is found here: [https://tzmcommunity.github.io/docs/creating-a-new-chapter-website-with-template/](https://tzmcommunity.github.io/docs/creating-a-new-chapter-website-with-template/)
+Documentation how to use this template is found here: <br>
+&nbsp;&nbsp; ●&nbsp; https://tzmcommunity.github.io/docs/creating-a-new-chapter-website-with-template/
 
 ## The Project's main structure
 


### PR DESCRIPTION
Fixed indentation for an URL of tzmcommunity.github.io/docs/creating-a-new-chapter-website-with-template/